### PR TITLE
fix v2 build on x86

### DIFF
--- a/old/v2/src/dis86.h
+++ b/old/v2/src/dis86.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I guess this is included from somewhere else in Mac land, but it failed on x86:

ninja@RYZEN:v2$ ./build.sh
The Meson build system
[...]
[3/27] Compiling C object src/libdis86.a.p/core.c.o
FAILED: src/libdis86.a.p/core.c.o
cc -Isrc/libdis86.a.p -Isrc -I../src -Isubprojects/bsl/src -I../subprojects/bsl/src -I/mnt/d/code/dis86/old/v2/src -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -g -std=c11 -fdiagnostics-color=always -D_GNU_SOURCE -Dtypeof=__typeof__ -g -fPIC -m64 -ffast-math -fno-associative-math -fno-reciprocal-math -fno-strict-aliasing -Wall -Werror -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -Wno-type-limits -Wno-empty-body -O2 -Wno-unused-variable -Wno-unused-but-set-variable -Wno-comments -fPIC -MD -MQ src/libdis86.a.p/core.c.o -MF src/libdis86.a.p/core.c.o.d -o src/libdis86.a.p/core.c.o -c ../src/core.c
In file included from ../src/dis86_private.h:3,
                 from ../src/core.c:1:
../src/dis86.h:72:24: error: unknown type name ‘uint16_t’
   72 |                        uint16_t                   seg,
      |                        ^~~~~~~~
../src/dis86.h:4:1: note: ‘uint16_t’ is defined in header ‘<stdint.h>’; did you forget to ‘#include <stdint.h>’?
    3 | #include <stdbool.h>
  +++ |+#include <stdint.h>
    4 |

IDK if we need an #ifdef for it to be a noop on Mac, but I expect it should not matter.